### PR TITLE
Adding new Statuscode "Battery so poor"

### DIFF
--- a/mc3000ble.py
+++ b/mc3000ble.py
@@ -58,6 +58,7 @@ class MC3000Ble:
         137: "battery over temperature",
         138: "short circuit",
         139: "wrong polarity",
+        140: "Battery so poor",
     }
 
     def __init__(self, ble_address, interval=1):


### PR DESCRIPTION
The charger is able to return a "140" if the battery is in a bad shape and refuses to charge any further. On the display it shows "Battery So Poor".

Thanks for the great project!